### PR TITLE
Reworking to speed up deploy to Heroku

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,0 @@
-libssl-dev
-libxml2-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM virtualstaticvoid/heroku-docker-r:plumber
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# ONBUILD will copy application files into the container
-#  and execute init.R (if it exists) and restore packrat packages (if they exist)
+# on build (from base image) will copy application files
 
 # provide the port for Plumber, so that running/testing outside of Heroku is possible
 # Heroku will override the PORT value at runtime

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,21 @@
+FROM virtualstaticvoid/heroku-docker-r:4.1.0
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update -q \
+  && apt-get install -qy \
+    libsodium-dev \
+    libssl-dev \
+    libxml2-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# only copy renv files (and _not_ application)
+COPY renv/* /app/renv/
+COPY .Rprofile /app/.Rprofile
+COPY renv.lock /app/renv.lock
+
+# restore renv to install packages
+RUN /usr/bin/R --no-save --slave -e 'renv::restore()'
+
+# create on build to copy application files
+ONBUILD COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,40 @@
+IMAGE_REPO ?= virtualstaticvoid/deployr7-example
+BASE_IMAGE := app-base
+APP_IMAGE := app
+
 # default build target
 all::
 
 .PHONY: all
 all:: build
 
-.PHONY: build
-build:
+renv.lock:
 
-	docker build --tag heroku-docker-r-example:plumber .
+	# only rebuild the base image if renv.lock changes
+
+	docker build --tag $(IMAGE_REPO):$(BASE_IMAGE) --file Dockerfile.base .
+
+.PHONY: build
+build: renv.lock
+
+	docker build \
+		--build-arg BASE_IMAGE=$(IMAGE_REPO):$(BASE_IMAGE) \
+		--tag $(IMAGE_REPO):$(APP_IMAGE) .
+
+.PHONY: publish
+publish:
+
+	# publish image to a remote repository (such as Docker Hub)
+	# which is accessible to Heroku for use during deployment (git push)
+
+	docker push $(IMAGE_REPO):$(BASE_IMAGE)
+
+	# see also https://devcenter.heroku.com/articles/container-registry-and-runtime for alternatives
 
 .PHONY: run
 run:
 
-	docker run -it -p "8080:8080" heroku-docker-r-example:plumber
+	docker run -it -p "8080:8080" $(IMAGE_REPO):$(APP_IMAGE)
 
 .PHONY: test
 test:

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,6 @@
 build:
   docker:
     web: Dockerfile
+
+  config:
+    BASE_IMAGE: virtualstaticvoid/deployr7-example:app-base

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.5",
+    "Version": "4.1.0",
     "Repositories": [
       {
         "Name": "CRAN",

--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -1,7 +1,7 @@
 external.libraries:
 ignored.packages:
 package.dependency.fields: Imports, Depends, LinkingTo
-r.version:
+r.version: 4.1.0
 snapshot.type: implicit
 use.cache: TRUE
 vcs.ignore.library: TRUE


### PR DESCRIPTION
Introduces a base image for renv and package dependencies. 

The base image should be published to a registry (public or private) which is accessible to Heroku.

The application is packaged in another image which uses the base image to include the application files.

A deployment to heroku (via git push) will be significantly faster since only the app image gets rebuilt each time.
